### PR TITLE
Navbar on features page has no margin/padding to the left

### DIFF
--- a/features/index.html
+++ b/features/index.html
@@ -32,10 +32,10 @@
                 </button>
             </div>
 
-            <div class="collapse navbar-collapse navbar-ex1-collapse navbar-features">
-                <ul class="nav navbar-nav navbar-features">
+            <div class="collapse navbar-collapse navbar-ex1-collapse">
+                <ul class="nav navbar-nav">
                     <li><a href="/">Home</a></li>
-                    <li class="active"><a href="#">Features</a></li>
+                    <li class="active"><a id="sharex-features" href="#">Features</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Tested locally, this fixes a minor issue where the nav doesn't look 'right' on the features page when on small devices like phones.

It's caused by the navbar-features CSS class which isn't really necessary.

The ID doesn't appear to be necessary either.