### PR TITLE
Add information about WineHQ for running on POSIX

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,6 +9,8 @@ ShareX is written using [C# programming language](https://en.wikipedia.org/wiki/
 
 Recently Microsoft released [.NET Core](https://en.wikipedia.org/wiki/.NET_Framework#.NET_Core) which supports writing multi platform software but it is currently extremely limited and doesn't have UI or graphic related libraries. So .NET Core is currently only viable to make console only applications.
 
+There is a project called [WineHQ](https://en.wikipedia.org/wiki/Wine_(software)) that tries to translate Windows APIs into POSIX calls for example for Linux-based distros. In theory, ShareX should run with Wine. It also installs successfully and basic functions like QR codes work. But native calls like capturing the screen, selecting a color on the screen crash ShareX and some symbols aren't really looking good.
+
 ### How do I get ShareX to upload to my custom domain?
 
 There are many ways to do this, we recommend using our guides [Google Cloud Storage](/docs/google-cloud-storage) and [Amazon S3](/docs/amazon-s3).


### PR DESCRIPTION
ShareX does run on Linux with wine and some native calls on Windows doesn't work. But i guess it is a mention worth.

![image](https://user-images.githubusercontent.com/76472134/121899798-45432380-cd14-11eb-848d-2e539d507e60.png)
![image](https://user-images.githubusercontent.com/76472134/121899984-728fd180-cd14-11eb-9e68-1fb2157369a0.png)
![image](https://user-images.githubusercontent.com/76472134/121900052-84717480-cd14-11eb-9f0f-9b485ee014f4.png)
