### PR TITLE
Fix hashtag spamming GitHub's API

### DIFF
--- a/js/sharex.downloads.js
+++ b/js/sharex.downloads.js
@@ -45,6 +45,7 @@ async function GetReleases(repo) {
         if (!response.ok) break;
 
         let releases = await response.json();
+        if (!Array.isArray(releases)) break;
 
         if (releases.length > 0) {
             releases = releases.sort((a, b) => new Date(b.published_at) - new Date(a.published_at));


### PR DESCRIPTION
Previously, this link would spam GitHub's API: 
https://getsharex.com/downloads?repo=ShareX/ShareX%23

The reason is when putting in a `#`, the response is the whole repository object, but the code expects an array, causing it to infinitely retry.